### PR TITLE
fix: Resolve shift history Firebase errors

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -116,6 +116,15 @@ service cloud.firestore {
         get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "master";
     }
 
+    // シフト変更ログコレクション - 店舗分離、マスターのみアクセス可能
+    match /shiftChangeLogs/{docId} {
+      allow read: if isAuthenticated() && 
+        isMasterOfStore(resource.data.storeId);
+      allow create: if isAuthenticated() && 
+        hasAccessToStore(request.resource.data.storeId);
+      allow update, delete: if false; // 追記専用
+    }
+
     // 未定義のパスは拒否
     match /{document=**} {
       allow read, write: if false;

--- a/src/services/shift-history/shiftHistoryLogger.ts
+++ b/src/services/shift-history/shiftHistoryLogger.ts
@@ -120,7 +120,7 @@ export const logShiftChange = async (
       actor,
       date: shift?.date || prevShift?.date || new Date().toISOString().split("T")[0],
       summary: "",
-      notes: metadata?.notes,
+      ...(metadata?.notes && { notes: metadata.notes }), // undefinedの場合はフィールドを除外
     };
 
     // 変更前後のデータを設定
@@ -154,11 +154,20 @@ export const logShiftChange = async (
       metadata
     );
 
-    // Firestoreに保存
-    await addDoc(collection(db, "shiftChangeLogs"), {
+    // Firestoreに保存（undefinedフィールドを除外）
+    const dataToSave = {
       ...entry,
       timestamp: serverTimestamp(),
+    };
+    
+    // undefinedフィールドを除外
+    Object.keys(dataToSave).forEach(key => {
+      if (dataToSave[key as keyof typeof dataToSave] === undefined) {
+        delete dataToSave[key as keyof typeof dataToSave];
+      }
     });
+    
+    await addDoc(collection(db, "shiftChangeLogs"), dataToSave);
   } catch (error) {
     // ログ記録の失敗は通常の操作を妨げないようにする
     if (__DEV__) {


### PR DESCRIPTION
## 修正内容

履歴機能のFirebaseエラーを修正しました。

### ✅ 修正した問題

1. **Firestore権限エラー**
   - `shiftChangeLogs`コレクションの権限をFirestore Rulesに追加
   - マスターユーザー: 読み取り可能
   - 全認証ユーザー: 作成可能（追記専用）

2. **undefinedフィールドエラー**  
   - `shiftHistoryLogger.ts`でundefined値をFirestoreに保存しないよう修正
   - notesフィールドがundefinedの場合はフィールド自体を除外

3. **データ検証**
   - Firestoreに保存前にundefinedフィールドを自動除外する処理を追加

### 🔧 変更ファイル
- `firestore.rules`: shiftChangeLogsコレクション権限追加
- `src/services/shift-history/shiftHistoryLogger.ts`: undefined値の除外処理

### 🧪 テスト方法
1. 履歴ボタンをクリックしてモーダルを開く
2. シフトを作成・編集・削除して履歴が記録されることを確認
3. コンソールエラーが出ないことを確認

Fixes the Firebase permission and validation errors reported in issue logs.

🤖 Generated with [Claude Code](https://claude.ai/code)